### PR TITLE
Supporting Non-standard HTTP Ports on Client Requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM vlipco/mini
+FROM centos:centos6
 MAINTAINER David Pelaez <david@vlipco.co>
 
 # this will handle unarchiving! no tar xzf needed
 ADD misc/ngx_openresty-1.7.2.1.tar.gz /openresty
 
 RUN cd /openresty/ngx_openresty-1.7.2.1 && \
-	yum install -y pcre-dev pcre-devel openssl-devel && ./configure && make install && \
-	ln -s /usr/local/openresty/nginx/sbin/nginx /usr/bin/nginx
+	yum install -y perl pcre-dev pcre-devel openssl-devel gcc && ./configure && make install && \
+	ln -s /usr/local/openresty/nginx/sbin/nginx /usr/bin/nginx && yum -y remove gcc
 
 ADD conf /nginx/conf
 RUN rm -rf /openresty && mkdir /nginx/logs

--- a/conf/srv_router.lua
+++ b/conf/srv_router.lua
@@ -24,6 +24,10 @@ function service_name(reqdomain)
                         pattern = "%.?" .. domain -- includes separation dot if present
                         --log("pattern: " .. pattern)
                         upstream = string.gsub(reqdomain,pattern,"")
+
+                        -- strip the port from the host header
+                        upstream = string.gsub(upstream,":%d+","")
+
                         if upstream == "" then
                                 return "home"
                         end


### PR DESCRIPTION
I was having issues with srv-router clients requests via anything but port 80.  This is because the HTTP spec requires ports be included in the host header.  The attached change strips and port specification from the host header.

The changes to the Dockerfile allowed me to build the project.  Your vlipco/mini image is not available publicly.  I was more comfortable building against a known upstream OS anyhow.  We can separate these changes if you like but I'd recommend using centos, or something similar, going forward.